### PR TITLE
Potential fix for code scanning alert no. 164: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/disnana/DictSQLite/security/code-scanning/164](https://github.com/disnana/DictSQLite/security/code-scanning/164)

To fix the problem, add a `permissions` block to the workflow to limit the token's access. The best place to add this in the current workflow is at the top level, just below the `name:` field and before or after `on:`. This will apply the permission restriction to all jobs within the workflow. The minimal privileges required for this workflow are `contents: read`, allowing the workflow to check out code but not giving it write access. No new imports, steps, or methods are required—this is a YAML configuration addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
