### PR TITLE
対応バージョンの誤りを修正

### DIFF
--- a/dictsqlite/main.py
+++ b/dictsqlite/main.py
@@ -16,7 +16,7 @@ import portalocker
 
 from dictsqlite.modules import crypto, utils
 
-__version__ = '1.8.1'  # バージョンアップ
+__version__ = '1.8.2'  # バージョンアップ
 
 # ロガーの設定
 logger = logging.getLogger(__name__)

--- a/pypi_builder/setup.py
+++ b/pypi_builder/setup.py
@@ -31,8 +31,6 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'License :: Other/Proprietary License',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
This pull request contains minor updates to versioning and package metadata.

- Bumped the project version from `1.8.1` to `1.8.2` in `dictsqlite/main.py` to reflect a new release.
- Updated the `pypi_builder/setup.py` classifiers to remove support for Python 3.7 and 3.8, indicating the project now officially supports Python 3.9 and above.