### PR TITLE
Potential fix for code scanning alert no. 410: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/disnana/DictSQLite/security/code-scanning/410](https://github.com/disnana/DictSQLite/security/code-scanning/410)

To fix the problem, add a `permissions` block to the workflow at the top level (above `jobs:`), limiting the GITHUB_TOKEN permissions to only those required by the workflow. For this workflow, the minimum required permission is `contents: read`, since actions like `actions/checkout`, installing dependencies, linting, running tests, and uploading coverage do not need write access to repository contents. If later you add steps that require additional permissions (e.g., commenting on pull requests), you can expand this block. Add the following block just after the `name:` entry (line 4) and before the `on:` key (line 6) in `.github/workflows/python-package.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
