### PR TITLE
v2.0.5にバージョンを変更

### DIFF
--- a/dictsqlite_v2/dictsqlite/Cargo.toml
+++ b/dictsqlite_v2/dictsqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dictsqlite"
-version = "2.0.4"
+version = "2.0.5"
 edition = "2021"
 authors = ["Disnana <support@disnana.com>"]
 description = "High-performance DictSQLite v2 with I/O optimizations (300x async, 43x sync speedup) - Buffered writes and batch operations"

--- a/dictsqlite_v2/dictsqlite/pyproject.toml
+++ b/dictsqlite_v2/dictsqlite/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "maturin"
 # PEP 621 project metadata required by maturin >= 0.14
 [project]
 name = "dictsqlite"
-version = "2.0.4"
+version = "2.0.5"
 description = "High-performance DictSQLite v2 with I/O optimizations"
 readme = "Pypi.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
This pull request updates the version of the `dictsqlite` package from 2.0.4 to 2.0.5 in both the Rust and Python project configuration files.

Version bump:

* Updated the `version` field in `dictsqlite_v2/dictsqlite/Cargo.toml` to 2.0.5 for the Rust crate.
* Updated the `version` field in `dictsqlite_v2/dictsqlite/pyproject.toml` to 2.0.5 for the Python package.