### PR TITLE
Potential fix for code scanning alert no. 7404: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   cargo-deny-v2:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2


### PR DESCRIPTION
Potential fix for [https://github.com/disnana/DictSQLite/security/code-scanning/7404](https://github.com/disnana/DictSQLite/security/code-scanning/7404)

In general, the fix is to explicitly set least-privilege `GITHUB_TOKEN` permissions for this workflow. Since the job only needs to read repository contents (for `actions/checkout` and for `cargo-deny` to read manifests), we can safely set `contents: read` and not grant any write or additional scopes.

The best fix without changing functionality is to add a `permissions` block scoped to the `cargo-deny-v2` job (or at the root); here we’ll add it at the job level, just under `runs-on: ubuntu-22.04`. This will ensure that `GITHUB_TOKEN` for this job has only read access to repository contents, satisfying the CodeQL rule while preserving existing behavior.

Concretely, in `.github/workflows/cargo-deny.yml`, insert:

```yaml
    permissions:
      contents: read
```

directly under the `runs-on: ubuntu-22.04` line in the `cargo-deny-v2` job. No imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
